### PR TITLE
verify_ssl fix

### DIFF
--- a/zbxapi.rb
+++ b/zbxapi.rb
@@ -107,9 +107,14 @@ class ZabbixAPI
 
     set_debug_level(options[:debug] || 0)
     @returntype=options[:returntype] || :result
-    @verify_ssl=options[:verify_ssl] || true
     @orig_url=url  #save the original url
     @url=URI.parse(url+'/api_jsonrpc.php')
+
+    if options.has_key?:verify_ssl
+      @verify_ssl=options[:verify_ssl]
+    else
+      @verify_ssl = true
+    end
 
     #Generate the list of sub objects dynamically, from all objects
     #derived from ZabbixAPI_Base


### PR DESCRIPTION
This fix pertains to the zbxapi.rb and specifically the issue with the verify_ssl always being set to true. 

Please accept this small fix for the verify_ssl bug.   
