### PR TITLE
Version 2.0 > 1.1

### DIFF
--- a/zbxapi.rb
+++ b/zbxapi.rb
@@ -312,8 +312,7 @@ class ZabbixAPI
     caller[0]=~/`(.*?)'/
     caller_func=$1
 
-    raise ZbxAPI_ExceptionVersion, "#{caller_func} requires API version #{major}.#{minor} or higher" if major>@major
-    raise ZbxAPI_ExceptionVersion, "#{caller_func} requires API version #{major}.#{minor} or higher" if minor>@minor
+    raise ZbxAPI_ExceptionVersion, "#{caller_func} requires API version #{major}.#{minor} or higher" if major>@major or (minor>@minor and major>=@major)
 
   end
 


### PR DESCRIPTION
Without this the version number test thinks 2.0 < 1.1 and refuses raw mode with:
"raw_api requires API version 1.1 or higher".
