### PR TITLE
Allow parameter macros in dsl_host create

### DIFF
--- a/api_classes/dsl_host.rb
+++ b/api_classes/dsl_host.rb
@@ -70,7 +70,7 @@ class Host < ZabbixAPI_Base
 
     parameters "2.0" do
       inherit from "1.3"
-      add "interfaces"
+      add "interfaces","macros"
     end
   end
 


### PR DESCRIPTION
Allow setting the macros parameter in host.create for zabbix >= 2.0
