### PR TITLE
Require 'interfaces' parameter for host.create 2.0 only

### DIFF
--- a/api_classes/dsl_host.rb
+++ b/api_classes/dsl_host.rb
@@ -65,12 +65,13 @@ class Host < ZabbixAPI_Base
       add "host","name","port","status","useip","dns","ip","proxy_hostid",
            "useipmi","ipmi_ip","ipmi_port","ipmi_authtype","ipmi_privilege",
            "ipmi_username","ipmi_password","groups","templates"
-      requires "groups","interfaces"
+      requires "groups"
     end
 
     parameters "2.0" do
       inherit from "1.3"
       add "interfaces","macros"
+      requires "interfaces"
     end
   end
 


### PR DESCRIPTION
Fixes Issue #15
