### PR TITLE
Check that custom headers isn't nil before setting

### DIFF
--- a/zbxapi.rb
+++ b/zbxapi.rb
@@ -131,7 +131,7 @@ class ZabbixAPI
     end
 
     if options.has_key?:custom_headers
-      @custom_headers = options[:custom_headers];
+      @custom_headers = options[:custom_headers] unless options[:custom_headers].nil?
     end
 
     #Generate the list of sub objects dynamically, from all objects


### PR DESCRIPTION
We hit an issue with Ruby 1.9.3 where @custom_headers was being overwritten by a nil hash, and the ZabbixAPI invocation was failing. Passing in :custom_headers => {} works, but it would be better to check that options[:custom_headers] isn't nil before setting it.
