### PR TITLE
Fixed the issue with uninitialized @custom_headers variable

### DIFF
--- a/zbxapi.rb
+++ b/zbxapi.rb
@@ -132,6 +132,8 @@ class ZabbixAPI
 
     if options.has_key?:custom_headers
       @custom_headers = options[:custom_headers] unless options[:custom_headers].nil?
+    else
+      @custom_headers = {}
     end
 
     #Generate the list of sub objects dynamically, from all objects


### PR DESCRIPTION
0.3.6 has introduced following issue:
gems/zbxapi-0.3.7/./zbxapi.rb:261:in `login': General Login error, check host connectivity. (ZbxAPI_ExceptionBadAuth)

In order to fix this @custom_headers variable needs to be initialized when class is instantiated.
