### PR TITLE
Fix for another 2.4 authentication problem using auth parameters

### DIFF
--- a/zbxapi.rb
+++ b/zbxapi.rb
@@ -195,10 +195,15 @@ class ZabbixAPI
         'id'=>@id
       }
 
+    # https://www.zabbix.com/documentation/2.4/manual/api/reference/apiinfo/version
+    # https://www.zabbix.com/documentation/2.4/manual/api/reference/user/login
     # Zabbix Doc(2.4): This method is available to unauthenticated
     #  users and must be called without the auth parameter
     #  in the JSON-RPC request.
-    obj.delete("auth") if method =~ /APIInfo/i
+    debug(4, :var => method,:msg => "Method:")
+    obj.delete("auth") if ["apiinfo.version",
+                           "user.login",
+                          ].any? { |str| method =~ /#{str}/i }
 
     debug(10, :msg=>"json_obj:  #{obj}")
     return obj.to_json


### PR DESCRIPTION
During the upgrade from 2.0.x to 2.4 we ran into a few issues with the zabbix api.  Specifically the APIInfo.version and the user.login calls.  Both of these calls now require that the auth parameter not be sent over the wire.  If they are sent the requests are returned as failures.

This fix is to remove the auth param for both the apiinfo.version and the user.login methods.

I have tested this method against 2.4 but do not have a < 2.4 version to run this against.  It shouldn't break because previously we were sending it to the server and it was accepting the auth param.  This should be backwards compatible.
