### PR TITLE
Skip authentication to get API version

### DIFF
--- a/zbxapi.rb
+++ b/zbxapi.rb
@@ -251,7 +251,7 @@ class ZabbixAPI
       @auth=result['result']
 
       #setup the version variables
-      @major,@minor=do_request(json_obj('APIInfo.version',{}))['result'].split('.')
+      @major,@minor=do_request(json_obj('apiinfo.version',{}))['result'].split('.')
       @major=@major.to_i
       @minor=@minor.to_i
     rescue ZbxAPI_ExceptionLoginPermission => e


### PR DESCRIPTION
Zabbix 2.2.3 compare case sensitive method name to skip authentication.
I request `APIInfo.version` and `apiinfo.version` to my zabbix server by curl.
`APIInfo.version` returns `"error":{"code":-32602,"message":"Invalid params.","data":"Not authorized"}`
`apiinfo.version` returns `"result":"2.2.3"` successfully.

Latest version of zabbix 2.2.x also has same compare logic.
Following code is `frontends/php/api/rpc/class.czbxrpc.php` in zabbix 2.2.7.
```
 42     // list of methods which does not require authentication
 43     $withoutAuth = array(
 44       'user.login' => 1,
 45       'user.checkAuthentication' => 1,
 46       'apiinfo.version' => 1
 47     );
 48     // Authentication
 49     if (!isset($withoutAuth[$method]) || !zbx_empty($sessionid)) {
```