### PR TITLE
fix login failure with zabbxi 2.2.* becase of maybe typo

### DIFF
--- a/zbxapi.rb
+++ b/zbxapi.rb
@@ -251,7 +251,7 @@ class ZabbixAPI
       @auth=result['result']
 
       #setup the version variables
-      @major,@minor=do_request(json_obj('APIInfo.version',{}))['result'].split('.')
+      @major,@minor=do_request(json_obj('apiinfo.version',{}))['result'].split('.')
       @major=@major.to_i
       @minor=@minor.to_i
     rescue ZbxAPI_ExceptionLoginPermission => e


### PR DESCRIPTION
I cannot login to zabbix, beacase login success but checkapi is fail.
debug log is below

```
irb(main):005:0> z.login(ZABBIX_USER, ZABBIX_PASSWORD)
"{\"jsonrpc\":\"2.0\",\"method\":\"user.login\",\"params\":{\"user\":\"AAAAA\",\"password\":\"BBBBB\"},\"id\":0}"
"c9aac1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
#<ZbxAPI_ExceptionLoginPermission: {"code"=>-32602, "message"=>"Invalid params.", "data"=>"Not authorized"}>
"{\"jsonrpc\":\"2.0\",\"method\":\"user.authenticate\",\"params\":{\"user\":\"AAAAA\",\"password\":\"BBBBB\"},\"auth\":\"c9aac1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\",\"id\":2}"
"0debeyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
#<ZbxAPI_ExceptionLoginPermission: {"code"=>-32602, "message"=>"Invalid params.", "data"=>"Not authorized"}>
ZbxAPI_ExceptionBadAuth: Invalid User or Password
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/zbxapi-0.3.10/zbxapi.rb:264:in `rescue in login'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/zbxapi-0.3.10/zbxapi.rb:249:in `login'
        from (irb):5
        from /opt/chef/embedded/bin/irb:12:in `<main>'
irb(main):006:0>
```
