### PR TITLE
Add compatibility 2.4 for update call

### DIFF
--- a/api_classes/dsl_host.rb
+++ b/api_classes/dsl_host.rb
@@ -139,7 +139,7 @@ class Host < ZabbixAPI_Base
       "ipmi_privilege","ipmi_username","jmx_available","jmx_disable_until",
       "jmx_error","jmx_errors_from","maintenance_from","maintenance_status",
       "maintenance_type","maintenanceid","name","proxy_hostid","snmp_available",
-      "snmp_disable_until","snmp_error","snmp_errors_from","status"
+      "snmp_disable_until","snmp_error","snmp_errors_from","status", "templates", "groups"
       requires "host"
     end
   end


### PR DESCRIPTION
With this modification, we can set groups and templates to links with host updated since zabbix options allow this